### PR TITLE
Fixes/findall decode

### DIFF
--- a/src/Sequelize/CRUD/Utils.purs
+++ b/src/Sequelize/CRUD/Utils.purs
@@ -1,0 +1,50 @@
+{-
+ Copyright (c) 2012-2017 "JUSPAY Technologies"
+ JUSPAY Technologies Pvt. Ltd. [https://www.juspay.in]
+
+ This file is part of JUSPAY Platform.
+
+ JUSPAY Platform is free software: you can redistribute it and/or modify
+ it for only educational purposes under the terms of the GNU Affero General
+ Public License (GNU AGPL) as published by the Free Software Foundation,
+ either version 3 of the License, or (at your option) any later version.
+ For Enterprise/Commerical licenses, contact <info@juspay.in>.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  The end user will
+ be liable for all damages without limitation, which is caused by the
+ ABUSE of the LICENSED SOFTWARE and shall INDEMNIFY JUSPAY for such
+ damages, claims, cost, including reasonable attorney fee claimed on Juspay.
+ The end user has NO right to claim any indemnification based on its use
+ of Licensed Software. See the GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/agpl.html>.
+-}
+
+module Sequelize.CRUD.Utils (mapInstanceToModel) where
+
+import Prelude
+
+import Data.Array ((:))
+import Data.Array as Array
+import Data.Either (Either(..))
+import Data.List.Types (NonEmptyList)
+import Data.Maybe (Maybe(..))
+import Foreign (ForeignError)
+import Sequelize.Class (class Model)
+import Sequelize.Instance (instanceToModelE)
+import Sequelize.Types (Instance)
+
+mapInstanceToModel :: forall a. Model a
+  => Array (Instance a) 
+  -> Either (NonEmptyList ForeignError) (Array a)
+mapInstanceToModel arr = mapToEither $ instanceToModelE <$> arr
+
+mapToEither :: forall err a. Array (Either err a) -> Either err (Array a)
+mapToEither arr = case Array.uncons arr of
+  Just {head : x, tail : xs} -> case x of
+    Left v -> Left v
+    Right v -> mapToEither xs >>= (\a -> Right (v : a))
+  Nothing -> Right []


### PR DESCRIPTION
1. In case of a decode error, `findAll` function was not throwing an error instead it was just changing it to `Nothing`. This is resulting in inconsistency. Fixed this.
3. Added updateModel'  to return an `Array a` instead of `Array (Instance a)`