### PR TITLE
attribute-func-defination-changed

### DIFF
--- a/src/Sequelize/Query/Options.purs
+++ b/src/Sequelize/Query/Options.purs
@@ -62,7 +62,7 @@ import Sequelize.Types (Alias, ModelOf, Transaction)
 where_ :: forall wh a. Model a => IsWhere wh => Option a (wh a)
 where_ = toWhere >$< opt "where"
 
-attributes :: forall a. Model a => Option a { include :: Array String, exclude :: Array String }
+attributes :: forall a. Model a => Option a (Array (Array String))
 attributes = opt "attributes"
 
 paranoid :: forall a. Model a => Option a Boolean


### PR DESCRIPTION
The function definition of attribute is incorrect, as in this file sequelize/lib/dialects/abstract/query-generator.js 
`options.attributes.slice()` and slice() works only on Array not on object.